### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/filepicker_rails/engine.rb
+++ b/lib/filepicker_rails/engine.rb
@@ -4,8 +4,10 @@ module FilepickerRails
     config.filepicker_rails = FilepickerRails::Configuration.new
     isolate_namespace FilepickerRails
 
-    initializer "filepicker_rails.form_builder" do
-      ActionView::Helpers::FormBuilder.send(:include, FilepickerRails::FormHelper)
+    initializer 'filepicker_rails.form_builder' do
+      Rails.application.reloader.to_prepare do
+        ActionView::Helpers::FormBuilder.send(:include, FilepickerRails::FormHelper)
+      end
     end
 
     initializer 'filepicker_rails.action_controller' do |app|


### PR DESCRIPTION
We are currently using Rails 6.1.7.3 and we are getting the following warning:

DEPRECATION WARNING: Initialization autoloaded the constant FilepickerRails::FormHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload FilepickerRails::FormHelper, for example,
the expected changes won't be reflected in that stale Module object.

`config.autoloader` is set to `classic`. This autoloaded constant would have been unloaded if `config.autoloader` had been set to `:zeitwerk`.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
It is suggested that we wrap ActionView::Helpers::FormBuilder.send(:include, FilepickerRails::FormHelper) in a to_prepare block in order to resolve this issue.